### PR TITLE
Broadcast keys to registry on wallet creation

### DIFF
--- a/chompchain/wallet/address.py
+++ b/chompchain/wallet/address.py
@@ -1,0 +1,30 @@
+from Crypto.Hash import keccak
+from Crypto.PublicKey.ECC import EccKey
+
+class Address:
+
+    def __init__(self, public_key: EccKey):
+        """ Constructor """
+        self.prefix = "0x"
+        print(type(public_key))
+        self.value = public_key
+
+    def __derive_address(self, public_key) -> str:
+        pub_key = public_key.export_key(format = 'raw')
+        addr_hash = keccak.new(digest_bits=256)
+        addr_hash.update(pub_key)
+        return addr_hash.hexdigest()[-40:]
+
+    @property
+    def value(self):
+        """ Getter for address value """
+        return f"{self.prefix}{self._value}"
+    
+    @value.setter
+    def value(self, pub_key: EccKey):
+        """ Setter for address value """
+        self._value = self.__derive_address(pub_key)
+
+    def __str__(self) -> str:
+        """ String representation """
+        return f"{self.prefix}{self._value}"

--- a/chompchain/wallet/wallet.py
+++ b/chompchain/wallet/wallet.py
@@ -1,4 +1,6 @@
 import os
+import json
+import requests
 from Crypto.PublicKey import RSA
 
 class Wallet:
@@ -33,4 +35,21 @@ class Wallet:
             os.system(f"chmod 600 {self.wallet_dir}/{key}")
 
     def __broadcast_keys(self):
-        pass
+        url = "https://dir.chain.chompe.rs/keys"  # the actual URL to send the keys
+        
+        payload = {
+            "user": "username",  # Replace with the actual username
+            "key": {
+                    "public_key": self.keys["cc_rsa.pub"].export_key().decode()
+            }
+        }
+        try:
+            response = requests.post(url, json=payload)
+            if response.status_code == 200:
+                print("Keys successfully broadcasted.")
+            else:
+                print("Failed to broadcast keys. Status code:", response.status_code)
+        except requests.exceptions.RequestException as e:
+            print("Error occurred during key broadcasting:", e)
+
+wallet = Wallet()

--- a/chompchain/wallet/wallet.py
+++ b/chompchain/wallet/wallet.py
@@ -12,8 +12,9 @@ class Wallet:
             os.mkdir(self.wallet_dir)
             self.__generate_keys()
             self.__set_permissions()
-            self.__broadcast_keys()
-        else: self.__open_keys()
+        else: self.__open_keys()   
+        self.__broadcast_keys()
+
 
     def __generate_keys(self):
         private_key = RSA.generate(4096)
@@ -40,7 +41,7 @@ class Wallet:
         payload = {
             "user": "username",  # Replace with the actual username
             "key": {
-                    "public_key": self.keys["cc_rsa.pub"].export_key().decode()
+                    "public_key": self.keys["cc_rsa.pub"].decode()
             }
         }
         try:

--- a/chompchain/wallet/wallet.py
+++ b/chompchain/wallet/wallet.py
@@ -2,9 +2,10 @@ import os
 import json
 import requests
 from Crypto.Hash import SHA256
-from Crypto.Hash import keccak
 from Crypto.PublicKey import ECC
 from Crypto.Signature import DSS
+
+from address import Address
 
 class Wallet:
 
@@ -19,7 +20,7 @@ class Wallet:
             self.__generate_keys()
             self.__set_permissions()
         self.__load_keys()
-        self.__derive_address()
+        self.address = Address(self.keys[".cc.pub"])
 
     def __generate_keys(self) -> None:
         private_key = ECC.generate(curve = 'P-256')
@@ -38,12 +39,6 @@ class Wallet:
         for key in self.keys:
             with open(f"{self.wallet_dir}/{key}", "rt") as fh:
                 self.keys[key] = ECC.import_key(fh.read())
-
-    def __derive_address(self) -> None:
-        pub_key = self.keys[".cc.pub"].export_key(format = 'raw')
-        addr_hash = keccak.new(digest_bits=256)
-        addr_hash.update(pub_key)
-        self.address = f"0x{addr_hash.hexdigest()[-40:]}"
 
     def __broadcast_keys(self) -> bool:
         url = "https://dir.chain.chompe.rs/keys"  # the actual URL to send the keys

--- a/chompchain/wallet/wallet.py
+++ b/chompchain/wallet/wallet.py
@@ -9,14 +9,17 @@ from Crypto.Signature import DSS
 class Wallet:
 
     def __init__(self):
-        self.keys = {}
+        self.keys = {
+            ".cc.priv": None,
+            ".cc.pub": None
+        }
         self.wallet_dir = os.path.expanduser("~/.wallet")
         if not os.path.isdir(self.wallet_dir):
             os.mkdir(self.wallet_dir)
             self.__generate_keys()
             self.__set_permissions()
-            self.__derive_address()
-            self.__broadcast_keys()
+        self.__load_keys()
+        self.__derive_address()
 
     def __generate_keys(self) -> None:
         private_key = ECC.generate(curve = 'P-256')
@@ -30,6 +33,11 @@ class Wallet:
         os.system(f"chmod 700 {self.wallet_dir}")
         for key in self.keys:
             os.system(f"chmod 600 {self.wallet_dir}/{key}")
+    
+    def __load_keys(self) -> dict:
+        for key in self.keys:
+            with open(f"{self.wallet_dir}/{key}", "rt") as fh:
+                self.keys[key] = ECC.import_key(fh.read())
 
     def __derive_address(self) -> None:
         pub_key = self.keys[".cc.pub"].export_key(format = 'raw')


### PR DESCRIPTION
From @dluman:

> Creates ability to broadcast keys from wallet; should happen on wallet creation only (or instantiation)? Is it possible that the main directory (`dir.chain.chompe.rs`) would be missing keys?

> Or, should we forward them with each `txn`? That seems to be too much.