### PR TITLE
Updating with tree creation regardless of block content

### DIFF
--- a/chompchain/chain.py
+++ b/chompchain/chain.py
@@ -16,9 +16,9 @@ class Chain:
         # all blocks not contained the leaf nodes?
         try:
             self.blocks = self.get_all_blocks()
-            self.tree = self.__construct_tree()
         except:
             print("Chain not started yet...")
+        self.tree = self.__construct_tree()
 
     def __construct_tree(self):
         block_tree = Tree()


### PR DESCRIPTION
CLI can't create blocks unless the `tree` is created regardless of whether or not a genesis block exists. With this update, it will create `self.tree` in any event.