### PR TITLE
Changing versioning to number-agnostic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 arglite==0.6.0
-chompchain_wallet==0.1
-couchsurf==0.3
+chompchain_wallet
+couchsurf
 pymerkle==5.0.3


### PR DESCRIPTION
Removing version numbers from requirements file to prevent `docker` image failure.